### PR TITLE
Fix fig.gca(projection = '3d')

### DIFF
--- a/2D Burgers Equation.py
+++ b/2D Burgers Equation.py
@@ -48,7 +48,7 @@ print("Plotting Innitial Solution: Cuboidic Wave Profile")
 print(lineSingle)
 
 fig = pyplot.figure(figsize=(11,7),dpi=100)          #Initializing the figure
-ax  = fig.gca(projection='3d')
+ax  = fig.add_subplot(projection = '3d')
 X,Y = numpy.meshgrid(x,y)
 
 ax.plot_surface(X,Y,u[:],cmap=cm.viridis,rstride=1,cstride=1)
@@ -98,7 +98,7 @@ print("Plotting Numerical Solution")
 print(lineSingle)
 
 fig = pyplot.figure(figsize=(11,7),dpi=100)
-ax  = fig.gca(projection='3d')
+ax  = fig.add_subplot(projection = '3d')
 
 X,Y = numpy.meshgrid(x,y)
 ax.plot_surface(X,Y,u[:],cmap=cm.viridis,rstride=1,cstride=1)

--- a/2D Diffusion Equation.py
+++ b/2D Diffusion Equation.py
@@ -40,7 +40,7 @@ print(lineSingle)
 
 
 fig = pyplot.figure()
-ax  = fig.gca(projection='3d')
+ax  = fig.add_subplot(projection = '3d')
 X,Y = numpy.meshgrid(x, y)
 surf = ax.plot_surface(X,Y,u, rstride=1, cstride=1, cmap=cm.viridis, linewidth=0, antialiased=False)
 
@@ -79,7 +79,7 @@ print("Plotting Numerical Solution")
 print(lineSingle)
 
 fig = pyplot.figure()
-ax  = fig.gca(projection='3d')
+ax  = fig.add_subplot(projection = '3d')
 surf = ax.plot_surface(X,Y,u[:], rstride=1, cstride=1, cmap=cm.viridis,linewidth=0, antialiased=True)
 ax.set_zlim(1, 2.5)
 

--- a/2D Laplace Equation.py
+++ b/2D Laplace Equation.py
@@ -11,7 +11,7 @@ print("Solving Laplace Equation using Finite Difference Method\n")
 def plot2D(x, y, p):
     
     fig = pyplot.figure(figsize=(11,7),dpi=100)
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection = '3d')
     
     X,Y=numpy.meshgrid(x,y)      #Generating 2D Mesh
     

--- a/2D Linear Convection Equation .py
+++ b/2D Linear Convection Equation .py
@@ -47,7 +47,7 @@ print("Plotting Innitial Solution: Cuboidic Wave Profile")
 print(lineSingle)
 
 fig = pyplot.figure(figsize=(11, 7), dpi=100)       #innitilize plot window
-ax  = fig.gca(projection = '3d')                    #defining axis is 3d
+ax  = fig.add_subplot(projection = '3d')            #defining axis is 3d
 X,Y = numpy.meshgrid(x, y)                          #Generating 2D Mesh
 
 #assign plot window the axes label ax, specifies its 3d projection plot
@@ -95,7 +95,7 @@ print("Plotting Numerical Solution")
 print(lineSingle)
 
 fig   = pyplot.figure(figsize=(11,7), dpi=100)
-ax    = fig.gca(projection = '3d')
+ax    = fig.add_subplot(projection = '3d')
 surf2 = ax.plot_surface(X, Y, u[:], cmap=cm.viridis)
 ax.set_title('Method - I:Using Nested FOR Loop')
 ax.set_xlabel('X Spacing')
@@ -133,7 +133,7 @@ print("Plotting Numerical Solution")
 print(lineSingle)
 
 fig = pyplot.figure(figsize=(11,7), dpi = 100)
-ax = fig.gca(projection = '3d')
+ax = fig.add_subplot(projection = '3d')
 surf3 = ax.plot_surface(X, Y, u[:], cmap = cm.viridis)
 ax.set_title('Method - II: Using ARRAYS Operation')
 ax.set_xlabel('X Spacing')

--- a/2D Non Linear Convection Equation .py
+++ b/2D Non Linear Convection Equation .py
@@ -42,7 +42,7 @@ print("Plotting Innitial Solution: Cuboidic Wave Profile")
 print(lineSingle)
 
 fig = pyplot.figure(figsize=(11, 7), dpi = 100)
-ax  = fig.gca(projection = '3d')
+ax  = fig.add_subplot(projection = '3d')
 X,Y = numpy.meshgrid(x, y)       #Generating 2D Mesh
 
 ax.plot_surface(X, Y, u[:],cmap=cm.viridis, rstride=2, cstride=2)
@@ -83,7 +83,7 @@ print("Plotting Numerical Solution")
 print(lineSingle)
 
 fig = pyplot.figure(figsize=(11, 7), dpi = 100)
-ax  = fig.gca(projection = '3d')
+ax  = fig.add_subplot(projection = '3d')
 X,Y = numpy.meshgrid(x, y)
 
 ax.plot_surface(X, Y, u[:],cmap=cm.viridis, rstride=2, cstride=2)

--- a/2D Poisson Equation.py
+++ b/2D Poisson Equation.py
@@ -45,7 +45,7 @@ b[int(3*ny/4),int(3*nx/4)] = -100
 
 def plot2D(x, y, p):
     fig = pyplot.figure(figsize=(11, 7), dpi=100)
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection = '3d')
 
     #Generating 2D Mesh    
     X, Y = numpy.meshgrid(x, y)
@@ -96,7 +96,7 @@ print(lineSingle)
 
 def plot2D(x, y, p):
     fig = pyplot.figure(figsize=(11, 7), dpi=100)
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection = '3d')
     
     X, Y = numpy.meshgrid(x, y)           #Generating 2D Mesh
     


### PR DESCRIPTION
Hi, this function is deprecated `fig.gca(projection = '3d') ` since [matplotlib 3.4.0](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.4.0.html#axes3d-automatically-adding-itself-to-figure-is-deprecated).